### PR TITLE
juju: filter out rotated unit logs

### DIFF
--- a/plugins/juju
+++ b/plugins/juju
@@ -3,7 +3,7 @@ if [ -d "var/log/juju" ]; then
     echo -e "juju:" >> $F_OUT
 
     readarray -t ps_units<<<"`egrep unit-\* ps| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*,\1,g;t;d'| sort -u`"
-    readarray -t log_units<<<"`find var/log/juju -name unit-\*| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*.log.*,\1,g;t;d'| sort -u`"
+    readarray -t log_units<<<"`find var/log/juju -name unit-\*.log| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*.log.*,\1,g;t;d'| sort -u`"
     combined_units=( `echo ${ps_units[@]} ${log_units[@]}| tr -s ' ' '\n'| sort -u` )
 
     readarray -t ps_machines<<<"`egrep machine-\* ps| sed -r 's,.+machine-([[:digit:]]+).*,\1,g;t;d'| sort -u`"


### PR DESCRIPTION
This removes from the list of log_units the rotated logs since otherwise
those are shown as stopped juju agents.

Before the patch:

    juju:
      machines:
        running:
          - 3 (version=unknown)
      units:
        running:
          - filebeat-64
          - hacluster-neutron-2
          - neutron-api-0
          - nrpe-68
          - telegraf-65
          - ceilometer-agent-47
        stopped:
          - ceilometer-agent-47-2020-04-19T03-46-36
          - filebeat-64-2019-04-11T07-15-23
          - filebeat-64-2019-08-20T04-42-42
          - hacluster-neutron-2-2019-07-15T07-46-49
          - neutron-api-0-2020-04-16T09-56-53
          - neutron-api-0-2020-05-28T08-35-46
          - nrpe-68-2019-07-15T07-20-04
          - telegraf-65-2019-08-28T20-20-29
          - telegraf-65-2020-03-10T19-23-47
          - ceilometer-agent-47-2019-09-30T08-15-27
        non-local (e.g. lxd):
          - null

After the patch:

    juju:
      machines:
        running:
          - 3 (version=unknown)
      units:
        running:
          - filebeat-64
          - hacluster-neutron-2
          - neutron-api-0
          - nrpe-68
          - telegraf-65
          - ceilometer-agent-47
        stopped:
        non-local (e.g. lxd):
          - null