### PR TITLE
hotsos: get absolute path of $0

### DIFF
--- a/hotsos.sh
+++ b/hotsos.sh
@@ -135,7 +135,7 @@ if ${PLUGINS[all]}; then
 fi
 
 export F_OUT=`mktemp`
-CWD=`dirname $0`
+CWD=$(dirname `realpath $0`)
 for SOS_ROOT in ${sos_paths[@]}; do
 (
     # TODO


### PR DESCRIPTION
Without this change hotsos.sh can't be executed with a relative path,
for example: ./hotsos.sh