### PR TITLE
Report OSD's fsid and device via lvm2

### DIFF
--- a/helpers
+++ b/helpers
@@ -5,7 +5,7 @@ get_ps ()
     local sos_path=${DATA_ROOT}ps
     if [ -e "$sos_path" ]; then
         cat $sos_path
-    else
+    elif ! [ -d "${DATA_ROOT}sos_commands" ]; then
         ps auxwww
     fi
 }

--- a/helpers
+++ b/helpers
@@ -69,3 +69,13 @@ get_udevadm_info_dev ()
 }
 export -f get_udevadm_info_dev
 
+get_lvm2_lvs ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/lvm2/lvs_-a_-o_lv_tags_devices*"
+    if [ -e $sos_path ]; then
+        cat $sos_path
+    elif ! [ -d "${DATA_ROOT}sos_commands" ] && which lvs >/dev/null; then
+        lvs -a -o lv_tags,devices,lv_kernel_read_ahead,lv_read_ahead,stripes,stripesize
+    fi
+}
+export -f get_lvm2_lvs

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -30,6 +30,10 @@ for svc in ${services[@]}; do
                 osd_device=`tail -n+$offset sos_commands/ceph/ceph-volume_lvm_list| grep -m1 "devices"| sed -r 's/.+\s+([[:alnum:]\/]+)/\1/g'`
                 out_str="$out_str (fsid=$osd_fsid) (device=$osd_device)"
             fi
+        else
+            declare -a arr=($(get_lvm2_lvs | awk -v id="osd_id=$osd_id" \
+                                             '/osd_fsid=/ && $0 ~ id {match($0, /osd_fsid=([^,]+)/,a); split($NF,b,"("); print a[1],b[1]}'))
+            [[ ${#arr[@]} == 2 ]] && out_str="$out_str (fsid=${arr[0]}) (device=${arr[1]})"
         fi
         output+=( "$out_str" )
     done


### PR DESCRIPTION
In some environments where OSDs may be deployed manually
via lvm2 (instead of ceph-volume). So we can get OSD data
from 'lvs' command in such cases.