### PR TITLE
Report OSDs' uptimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# hotsos
+
+This tool is intended to be used to extract information out of
+sos reports that are commonly looked at when debugging problems.
+It has a number of *plugins* that deal with extracting application
+specific information.
+
+It's designed to be able to run on both live systems as well as
+sos reports.
+
+It has multiple *verbosity* levels (`-v` flag) to get more fine-grained
+information about one or more applications.
+
+NOTE: hotsos is not intended to replace the functionality of
+[xsos](https://github.com/ryran/xsos); rather this is directed towards extracting application specific
+information that's not covered by xsos.
+
+### Usage
+
+- Get the list of plugins:
+> hotsos --list-plugins
+
+- Get details about *openstack*:
+> hotsos /path/to/sos/report --openstack
+
+- Get more details on *openstack*:
+> hotsos /path/to/sos/report --openstack -v
+
+- And even more details:
+> hotsos /path/to/sos/report --openstack -vvv
+

--- a/helpers
+++ b/helpers
@@ -11,6 +11,18 @@ get_ps ()
 }
 export -f get_ps
 
+get_ps_axo_flags ()
+{
+    # Older sosrepot uses 'wchan' option while newer ones use 'wchan:20' - thus the glob is to cover both
+    local sos_path="${DATA_ROOT}/sos_commands/process/ps_axo_flags_state_uid_pid_ppid_pgid_sid_cls_pri_addr_sz_wchan*_lstart_tty_time_cmd"
+    if [ -e $sos_path ]; then
+        cat $sos_path
+    elif ! [ -d "${DATA_ROOT}sos_commands" ]; then
+        ps axo flags,state,uid,pid,ppid,pgid,sid,cls,pri,addr,sz,wchan:20,lstart,tty,time,cmd
+    fi
+}
+export -f get_ps_axo_flags
+
 get_uptime ()
 {
     local sos_path=${DATA_ROOT}uptime
@@ -80,5 +92,26 @@ seconds_to_date ()
 
     printf '%02dd:%02dh:%02dm:%02ds' $days $hours $mins $secs
 }
-
 export -f seconds_to_date
+
+get_sosreport_time ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/date/date"
+    if [ -s "$sos_path" ]; then
+        date --date="$(cat $sos_path)" +%s
+    elif ! [ -d "${DATA_ROOT}sos_commands" ]; then
+        date +%s
+    fi
+}
+export -f get_sosreport_time
+
+get_ceph_volume ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/ceph/ceph-volume_lvm_list"
+    if [ -s "$sos_path" ]; then
+        cat "$sos_path"
+    elif ! [ -d "${DATA_ROOT}sos_commands" ] && which ceph-volume >/dev/null; then
+        ceph-volume lvm list
+    fi
+}
+export -f get_ceph_volume

--- a/helpers
+++ b/helpers
@@ -58,7 +58,7 @@ get_ls_lanR_sys_block ()
 export -f get_ls_lanR_sys_block
 
 get_udevadm_info_dev ()
-{   
+{
     local dev="$1"
     local sos_path=${DATA_ROOT}sos_commands/block/udevadm_info_.dev.$dev
     if [ -e "$sos_path" ]; then
@@ -69,3 +69,16 @@ get_udevadm_info_dev ()
 }
 export -f get_udevadm_info_dev
 
+# Converts the given seconds ($1) to DDd:HHh:MMh:SSs format
+seconds_to_date ()
+{
+    local seconds="$1"
+    local days=$((seconds/86400))
+    local hours=$((seconds/3600%24))
+    local mins=$((seconds/60%60))
+    local secs=$((seconds%60))
+
+    printf '%02dd:%02dh:%02dm:%02ds' $days $hours $mins $secs
+}
+
+export -f seconds_to_date

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -11,6 +11,8 @@ services=(
 
 echo "ceph:"
 
+sos_time_secs=$(date --date="$(cat sos_commands/date/date)" +%s)
+
 for svc in ${services[@]}; do
     exists="`get_ps| sed -r \"s/.*(${svc}[[:alnum:]\-]*)\s+.+/\1/g;t;d\"| sort -u| sed -r 's/^\s+/  /g'`"
     [ -z "$exists" ] && continue
@@ -18,9 +20,21 @@ for svc in ${services[@]}; do
     ids="`get_ps| sed -r \"s/.*(${svc}[[:alnum:]\-]*)\s+.+--id\s+([[:digit:]]+)\s+.+/\2/g;t;d\"| tr -s '\n' ','| sort| sed -r -e 's/^\s+/  /g' -e 's/,$//g'`"
     for osd_id in `echo $ids| tr ',' ' '`;do
         out_str="ceph-osd (id=$osd_id)"
+
         if ((VERBOSITY_LEVEL>=1)); then
+            # OSD's Resident memory size
             osd_RSS=$(awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print int($8/1024)}' sos_commands/process/ps_alxwww)
             out_str="$out_str (RSS=${osd_RSS}M)"
+
+            # OSD's uptime (time since it was started)
+            osd_start="$(awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print $13, $14, $15, $16, $17; exit}' \
+                         sos_commands/process/ps_axo_flags_state_uid_pid_ppid_pgid_sid_cls_pri_addr_sz_wchan*_lstart_tty_time_cmd)"
+            if [[ $sos_time_secs -gt 0 && -n "$osd_start" ]]; then
+                osd_start_secs=$(date --date="${osd_start}" +%s)
+                osd_uptime_secs=$((sos_time_secs - osd_start_secs))
+                osd_uptime_str="$(seconds_to_date $osd_uptime_secs)"
+                out_str="$out_str (up=$osd_uptime_str)"
+            fi
         fi
 
         if [ -s "sos_commands/ceph/ceph-volume_lvm_list" ]; then

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -11,7 +11,7 @@ services=(
 
 echo "ceph:"
 
-sos_time_secs=$(date --date="$(cat sos_commands/date/date)" +%s)
+sos_time_secs=$(get_sosreport_time)
 
 for svc in ${services[@]}; do
     exists="`get_ps| sed -r \"s/.*(${svc}[[:alnum:]\-]*)\s+.+/\1/g;t;d\"| sort -u| sed -r 's/^\s+/  /g'`"
@@ -19,32 +19,30 @@ for svc in ${services[@]}; do
 
     ids="`get_ps| sed -r \"s/.*(${svc}[[:alnum:]\-]*)\s+.+--id\s+([[:digit:]]+)\s+.+/\2/g;t;d\"| tr -s '\n' ','| sort| sed -r -e 's/^\s+/  /g' -e 's/,$//g'`"
     for osd_id in `echo $ids| tr ',' ' '`;do
-        out_str="ceph-osd (id=$osd_id)"
+        out_str="ceph-osd.$osd_id"
+
+        offset=`get_ceph_volume | egrep -n "osd id\s+$osd_id\$" | cut -f1 -d:`
+        if [ -n "$offset" ]; then
+            osd_fsid=`get_ceph_volume | tail -n+$offset | grep -m1 "osd fsid" | sed -r 's/.+\s+([[:alnum:]]+)/\1/g'`
+            osd_device=`get_ceph_volume | tail -n+$offset | grep -m1 "devices" | sed -r 's/.+\s+([[:alnum:]\/]+)/\1/g'`
+            out_str="$out_str (fsid=$osd_fsid) (device=$osd_device)"
+        fi
 
         if ((VERBOSITY_LEVEL>=1)); then
             # OSD's Resident memory size
-            osd_RSS=$(awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print int($8/1024)}' sos_commands/process/ps_alxwww)
+            osd_RSS=$(get_ps | awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print int($6/1024)}')
             out_str="$out_str (RSS=${osd_RSS}M)"
 
             # OSD's uptime (time since it was started)
-            osd_start="$(awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print $13, $14, $15, $16, $17; exit}' \
-                         sos_commands/process/ps_axo_flags_state_uid_pid_ppid_pgid_sid_cls_pri_addr_sz_wchan*_lstart_tty_time_cmd)"
+            osd_start="$(get_ps_axo_flags | awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print $13, $14, $15, $16, $17; exit}')"
             if [[ $sos_time_secs -gt 0 && -n "$osd_start" ]]; then
                 osd_start_secs=$(date --date="${osd_start}" +%s)
                 osd_uptime_secs=$((sos_time_secs - osd_start_secs))
                 osd_uptime_str="$(seconds_to_date $osd_uptime_secs)"
-                out_str="$out_str (up=$osd_uptime_str)"
+                out_str="$out_str (etime=$osd_uptime_str)"
             fi
         fi
 
-        if [ -s "sos_commands/ceph/ceph-volume_lvm_list" ]; then
-            offset=`egrep -n "osd id\s+$osd_id\$" sos_commands/ceph/ceph-volume_lvm_list| cut -f1 -d:`
-            if [ -n "$offset" ]; then
-                osd_fsid=`tail -n+$offset sos_commands/ceph/ceph-volume_lvm_list| grep -m1 "osd fsid"| sed -r 's/.+\s+([[:alnum:]]+)/\1/g'`
-                osd_device=`tail -n+$offset sos_commands/ceph/ceph-volume_lvm_list| grep -m1 "devices"| sed -r 's/.+\s+([[:alnum:]\/]+)/\1/g'`
-                out_str="$out_str (fsid=$osd_fsid) (device=$osd_device)"
-            fi
-        fi
         output+=( "$out_str" )
     done
 done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description:
   Sosreports contain tons of system information and sometimes it is
   nice to start with a summary of contents that we would typically
   spend time search for.
-confinement: strict 
+confinement: strict
 grade: stable
 base: core18
 


### PR DESCRIPTION
Report how long the OSDs are running for.

The time reported is in DD:HH:MM:SS format (DD = days; HH = hours; MM = minutes; SS = seconds).