### PR TITLE
[plugins/storage] Report OSD's fsid and device via lvm2

### DIFF
--- a/helpers
+++ b/helpers
@@ -115,3 +115,15 @@ get_ceph_volume_lvm_list ()
     fi
 }
 export -f get_ceph_volume_lvm_list
+
+get_lvm2_lvs ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/lvm2/lvs_-a_-o_lv_tags_devices*"
+    if [ -e $sos_path ]; then
+        cat $sos_path
+    elif ! [ -d "${DATA_ROOT}sos_commands" ] && which lvs >/dev/null; then
+        lvs -a -o lv_tags,devices
+    fi
+}
+export -f get_lvm2_lvs
+

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -26,6 +26,11 @@ for svc in ${services[@]}; do
             osd_fsid=`get_ceph_volume_lvm_list | tail -n+$offset | grep -m1 "osd fsid" | sed -r 's/.+\s+([[:alnum:]]+)/\1/g'`
             osd_device=`get_ceph_volume_lvm_list | tail -n+$offset | grep -m1 "devices" | sed -r 's/.+\s+([[:alnum:]\/]+)/\1/g'`
             out_str="$out_str (fsid=$osd_fsid) (device=$osd_device)"
+        else
+            declare -a arr=($(get_lvm2_lvs |
+                              awk -v id="osd_id=$osd_id" '/osd_fsid=/ && $0 ~ id {
+                              match($0, /osd_fsid=([^,]+)/,a); split($NF,b,"("); print a[1],b[1]; exit }'))
+            [[ ${#arr[@]} == 2 ]] && out_str="$out_str (fsid=${arr[0]}) (device=${arr[1]})"
         fi
 
         if ((VERBOSITY_LEVEL>=1)); then


### PR DESCRIPTION
In some environments where OSDs may be deployed manually
via lvm2 (instead of juju/ceph-volume). So we can get OSD data
from 'lvs' command in such cases.