### PR TITLE
Use POSIX character class instead of GNU extension

### DIFF
--- a/plugins/openstack/02vm_info
+++ b/plugins/openstack/02vm_info
@@ -8,7 +8,7 @@ echo "  vms:"
 
 vm_indent="  ${INDENT_STR}"
 
-readarray -t uuids<<<`get_ps| grep "product=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[\s,]+.+/\1/g'`
+readarray -t uuids<<<`get_ps| grep "product=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[[:space:],]+.+/\1/g'`
 for uuid in ${uuids[@]}; do
     output+=( "$uuid" )
 done


### PR DESCRIPTION
The sed regex doesn't work for me because `\s` isn't working.

`\s` is a GNU extension and *should* work as I am using GNU sed - but I can't explain why it doesn't. 
A standalone example of what's not working:
```
echo "ibvirt+   9482 89.2  0.0 13092808 60172 ?      SLl  May21 1068:30 qemu-system-x86_64 -enable-kvm -name instance-00000df0 -S -machine pc-i440fx-xenial,accel=kvm,usb=off -cpu Broadwell-IBRS,+abm,+pdpe1gb,+rdrand,+f16c,+osxsave,+dca,+pdcm,+xtpr,+tm2,+est,+smx,+vmx,+ds_cpl,+monitor,+dtes64,+pbe,+tm,+ht,+ss,+acpi,+ds,+vme -m 8192 -realtime mlock=off -smp 4,sockets=4,cores=1,threads=1 -object memory-backend-file,id=ram-node0,prealloc=yes,mem-path=/mnt/hugepages_1GB/libvirt/qemu,share=yes,size=8589934592,host-nodes=0,policy=bind -numa node,nodeid=0,cpus=0-3,memdev=ram-node0 -uuid 67c02ef1-c6d8-46ed-b9bd-df41eb1cad89 -smbios type=1,manufacturer=OpenStack Foundation,product=OpenStack Nova,version=2015.1.0,serial=5e3ae7d8-b911-4750-add0-0c7d22ed1d9b,uuid=67c02ef1-c6d8-46ed-b9bd-df41eb1cad89 -no-user-config -nodefaults -chardev socket,id=charmonitor,path=/var/lib/libvirt/qemu/domain-instance-00000df0/monitor.sock,server,nowait -mon chardev=charmonitor,id=monitor,mode=control -rtc base=utc,driftfix=slew -global kvm-pit.lost_tick_policy=discard -no-hpet -no-shutdown -boot strict=on -device piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2 -drive file=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/disk,format=qcow2,if=none,id=drive-virtio-disk0,cache=directsync -device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x4,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1 -drive file=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/disk.config,format=raw,if=none,id=drive-ide0-1-1,readonly=on,cache=directsync -device ide-cd,bus=ide.1,unit=1,drive=drive-ide0-1-1,id=ide0-1-1 -netdev tap,ifname=tap0f47cc32-1a,script=,id=hostnet0,vhost=on,vhostfd=26 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=02:0f:47:cc:32:1a,bus=pci.0,addr=0x3 -chardev file,id=charserial0,path=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/console.log -device isa-serial,chardev=charserial0,id=serial0 -chardev pty,id=charserial1 -device isa-serial,chardev=charserial1,id=serial1 -device usb-tablet,id=input0 -vnc 0.0.0.0:0 -k en-us -device cirrus-vga,id=video0,bus=pci.0,addr=0x2 -device vfio-pci,host=03:17.4,id=hostdev0,bus=pci.0,addr=0x5 -device vfio-pci,host=03:17.5,id=hostdev1,bus=pci.0,addr=0x6 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x7 -msg timestamp=on" | sed -r 's/.+uuid=([[:alnum:]\-]+)[\s,]+.+/\1/g'
```

But the change should work universally whether GNU extension is available.

EDIT:

I think the problem is the checking multiple characters inside `[]` (i.e. `[\s,]`) doesn't understand the `\s`. Using `\s` *outside* `[]` works as expected.
