### PR TITLE
[plugin/openstack] Ignore comments when parsing

### DIFF
--- a/plugins/openstack/01openstack
+++ b/plugins/openstack/01openstack
@@ -6,12 +6,12 @@ declare -a ost_projects=(
     aodh
     barbican
     ceilometer
-    cinder  
+    cinder
     designate
     glance
     gnocchi
     heat
-    horizon 
+    horizon
     keystone
     neutron
     nova
@@ -26,7 +26,7 @@ data_source=`ls -rt ${DATA_ROOT}etc/apt/sources.list.d/*.list| xargs -l grep -l 
 if [ -s "$data_source" ]; then
     if [ -d "`dirname \"$data_source\"`" ] && `grep -qr ubuntu-cloud.archive $data_source 2>/dev/null`; then
         ost_rel="`grep -r ubuntu-cloud.archive $data_source| grep -v deb-src |\
-            sed -r 's/.+-updates\/(.+)\s+.+/\1/g;t;d'`"
+            sed -r '/^\s*#/!s/.+-updates\/(.+)\s+.+/\1/g;t;d'`"
         [ -n "$ost_rel" ] || ost_rel=unknown
         echo "$ost_rel (uca)"
     else
@@ -47,7 +47,7 @@ if ((VERBOSITY_LEVEL>=2)); then
         [ -z ${ost_etc_overrides[$proj]:-""} ] || \
             path=etc/$proj/${ost_etc_overrides[$proj]}
         [ -e "$path" ] || continue
-        debug=`sed -rn 's/debug\s*=\s*(.+)\s*/\1/p' $path`
+        debug=`sed -rn '/^\s*#/!s/debug\s*=\s*(.+)\s*/\1/p' $path`
         echo "$svc_indent$proj: $debug"
     done
 fi

--- a/plugins/openstack/04package_versions
+++ b/plugins/openstack/04package_versions
@@ -6,12 +6,12 @@ declare -a ost_projects=(
     aodh
     barbican
     ceilometer
-    cinder  
+    cinder
     designate
     glance
     gnocchi
     heat
-    horizon 
+    horizon
     keystone
     neutron
     nova
@@ -29,6 +29,6 @@ for proj in ${ost_projects[@]}; do
     for pkg in ${packages[@]}; do
         ver=`egrep "^ii\s+$pkg " $data_source| awk '{print $3}'`
         echo "  $INDENT_STR$pkg $ver"
-    done | sort -k2 
+    done | sort -k2
 done
 

--- a/plugins/openstack/05network
+++ b/plugins/openstack/05network
@@ -8,7 +8,7 @@ found=false
 data_source=${DATA_ROOT}etc/nova/nova.conf
 if [ -e "$data_source" ]; then
     found=true
-    my_ip=`sed -rn 's/^\s*my_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
+    my_ip=`sed -rn '/^\s*#/!s/^\s*my_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
     if [ -n "$my_ip" ]; then
         data_source2=${DATA_ROOT}sos_commands/networking/ip_-d_address
         iface="<interface unknown>"
@@ -25,7 +25,7 @@ fi
 data_source=${DATA_ROOT}etc/neutron/plugins/ml2/openvswitch_agent.ini
 if [ -e "$data_source" ]; then
     found=true
-    local_ip=`sed -rn 's/^\s*local_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
+    local_ip=`sed -rn '/^\s*#/!s/^\s*local_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
     if [ -n "$local_ip" ]; then
         data_source2=${DATA_ROOT}sos_commands/networking/ip_-d_address
         iface="<interface unknown>"


### PR DESCRIPTION
When parsing config files (/etc), there may be comments that
match the pattern we're after. Ignore them.

Example output with this bug:
```
openstack:
  release: distro
  debug-logging-enabled:
    - ceilometer: #nova_http_log_false
#false
True
#pecan_false
#connection_0
    - neutron: # False
True
# connection_0
    - nova: #false
True
  services:
    - ceilometer-polling (1)
    - nova-compute (1)
    - qemu-system-x86_64 (3)

<---- clipped output here --->
```