### PR TITLE
[plugin/openstack] use posix character set instead of GNU extension

### DIFF
--- a/plugins/juju/01juju
+++ b/plugins/juju/01juju
@@ -16,11 +16,11 @@ if ! [ -d "$data_source_dir" ]; then
     exit 0
 fi
 
-readarray -t ps_units<<<"`get_ps| grep unit-| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*,\1,g;t;d'| sort -u`"
+readarray -t ps_units<<<"`get_ps| grep [u]nit-| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*,\1,g;t;d'| sort -u`"
 readarray -t log_units<<<"`find ${DATA_ROOT}var/log/juju -name unit-\*.log| sed -r 's,.+unit-([[:alnum:]\-]+-[[:digit:]]+).*.log.*,\1,g;t;d'| sort -u`"
 combined_units=( `echo ${ps_units[@]} ${log_units[@]}| tr -s ' ' '\n'| sort -u` )
 
-readarray -t ps_machines<<<"`get_ps| egrep machine-\*| sed -r 's,.+machine-([[:digit:]]+).*,\1,g;t;d'| sort -u`"
+readarray -t ps_machines<<<"`get_ps| egrep [m]achine-\*| sed -r 's,.+machine-([[:digit:]]+).*,\1,g;t;d'| sort -u`"
 readarray -t log_machines<<<"`find ${DATA_ROOT}var/log/juju -name machine-\*| sed -r 's,.+machine-([[:digit:]]+).*.log.*,\1,g;t;d'| sort -u`"
 
 declare -a juju_machine_running=()

--- a/plugins/openstack/01openstack
+++ b/plugins/openstack/01openstack
@@ -6,12 +6,12 @@ declare -a ost_projects=(
     aodh
     barbican
     ceilometer
-    cinder  
+    cinder
     designate
     glance
     gnocchi
     heat
-    horizon 
+    horizon
     keystone
     neutron
     nova
@@ -26,7 +26,7 @@ data_source=`ls -rt ${DATA_ROOT}etc/apt/sources.list.d/*.list| xargs -l grep -l 
 if [ -s "$data_source" ]; then
     if [ -d "`dirname \"$data_source\"`" ] && `grep -qr ubuntu-cloud.archive $data_source 2>/dev/null`; then
         ost_rel="`grep -r ubuntu-cloud.archive $data_source| grep -v deb-src |\
-            sed -r 's/.+-updates\/(.+)\s+.+/\1/g;t;d'`"
+            sed -r '/^\s*#/!s/.+-updates\/(.+)\s+.+/\1/g;t;d'`"
         [ -n "$ost_rel" ] || ost_rel=unknown
         echo "$ost_rel (uca)"
     else
@@ -47,7 +47,7 @@ if ((VERBOSITY_LEVEL>=2)); then
         [ -z ${ost_etc_overrides[$proj]:-""} ] || \
             path=etc/$proj/${ost_etc_overrides[$proj]}
         [ -e "$path" ] || continue
-        debug=`sed -rn 's/debug\s*=\s*(.+)\s*/\1/p' $path`
+        debug=`sed -rn '/^\s*#/!s/debug\s*=\s*(.+)\s*/\1/p' $path`
         echo "$svc_indent$proj: $debug"
     done
 fi

--- a/plugins/openstack/02vm_info
+++ b/plugins/openstack/02vm_info
@@ -4,20 +4,20 @@ declare -a output=()
 
 ((VERBOSITY_LEVEL>=1)) || exit 0
 
-echo "  vms:"
-
 vm_indent="  ${INDENT_STR}"
 
-readarray -t uuids<<<`get_ps| grep "product=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[[:space:],]+.+/\1/g'`
+readarray -t uuids<<<`get_ps| grep "[p]roduct=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[[:space:],]+.+/\1/g'`
 for uuid in ${uuids[@]}; do
     output+=( "$uuid" )
 done
 
 if ((${#output[@]})); then
+    echo "  instances (${#output[@]}):"
     for line in "${output[@]}"; do
         echo "${vm_indent}$line"
     done
 else
+    echo "  vms:"
     echo "${vm_indent}null"
 fi
 

--- a/plugins/openstack/02vm_info
+++ b/plugins/openstack/02vm_info
@@ -8,7 +8,7 @@ echo "  vms:"
 
 vm_indent="  ${INDENT_STR}"
 
-readarray -t uuids<<<`get_ps| grep "product=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[\s,]+.+/\1/g'`
+readarray -t uuids<<<`get_ps| grep "product=OpenStack Nova"| sed -r 's/.+uuid=([[:alnum:]\-]+)[[:space:],]+.+/\1/g'`
 for uuid in ${uuids[@]}; do
     output+=( "$uuid" )
 done

--- a/plugins/openstack/04package_versions
+++ b/plugins/openstack/04package_versions
@@ -6,12 +6,12 @@ declare -a ost_projects=(
     aodh
     barbican
     ceilometer
-    cinder  
+    cinder
     designate
     glance
     gnocchi
     heat
-    horizon 
+    horizon
     keystone
     neutron
     nova
@@ -29,6 +29,6 @@ for proj in ${ost_projects[@]}; do
     for pkg in ${packages[@]}; do
         ver=`egrep "^ii\s+$pkg " $data_source| awk '{print $3}'`
         echo "  $INDENT_STR$pkg $ver"
-    done | sort -k2 
+    done | sort -k2
 done
 

--- a/plugins/openstack/05network
+++ b/plugins/openstack/05network
@@ -8,7 +8,7 @@ found=false
 data_source=${DATA_ROOT}etc/nova/nova.conf
 if [ -e "$data_source" ]; then
     found=true
-    my_ip=`sed -rn 's/^\s*my_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
+    my_ip=`sed -rn '/^\s*#/!s/^\s*my_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
     if [ -n "$my_ip" ]; then
         data_source2=${DATA_ROOT}sos_commands/networking/ip_-d_address
         iface="<interface unknown>"
@@ -25,7 +25,7 @@ fi
 data_source=${DATA_ROOT}etc/neutron/plugins/ml2/openvswitch_agent.ini
 if [ -e "$data_source" ]; then
     found=true
-    local_ip=`sed -rn 's/^\s*local_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
+    local_ip=`sed -rn '/^\s*#/!s/^\s*local_ip\s*=\s*([[:digit:]\.]+).*/\1/p' $data_source`
     if [ -n "$local_ip" ]; then
         data_source2=${DATA_ROOT}sos_commands/networking/ip_-d_address
         iface="<interface unknown>"

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -29,13 +29,14 @@ for svc in ${services[@]}; do
         else
             declare -a arr=($(get_lvm2_lvs |
                               awk -v id="osd_id=$osd_id" '/osd_fsid=/ && $0 ~ id {
-                              match($0, /osd_fsid=([^,]+)/,a); split($NF,b,"("); print a[1],b[1]; exit }'))
+                              match($0, /osd_fsid=([^,]+)/); a=substr($0, RSTART+1, RLENGTH-1);
+                              split($NF, b, "("); print a, b[1]; exit }'))
             [[ ${#arr[@]} == 2 ]] && out_str="$out_str (fsid=${arr[0]}) (device=${arr[1]})"
         fi
 
         if ((VERBOSITY_LEVEL>=1)); then
             # OSD's Resident memory size
-            osd_RSS=$(get_ps | awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print int($6/1024)}')
+            osd_RSS=$(get_ps | awk -v id="--id $osd_id " '/ceph-osd/ && $0 ~ id {print int($6/1024); exit}')
             out_str="$out_str (RSS=${osd_RSS}M)"
 
             # OSD's uptime (time since it was started)


### PR DESCRIPTION
The sed regex doesn't work for me because `\s` isn't working.

I think the problem is the checking multiple characters inside `[]` (i.e. `[\s,]`) doesn't understand the `\s`. Using `\s` *outside* `[]` works as expected.

A standalone example of what's not working:
```
echo "ibvirt+   9482 89.2  0.0 13092808 60172 ?      SLl  May21 1068:30 qemu-system-x86_64 -enable-kvm -name instance-00000df0 -S -machine pc-i440fx-xenial,accel=kvm,usb=off -cpu Broadwell-IBRS,+abm,+pdpe1gb,+rdrand,+f16c,+osxsave,+dca,+pdcm,+xtpr,+tm2,+est,+smx,+vmx,+ds_cpl,+monitor,+dtes64,+pbe,+tm,+ht,+ss,+acpi,+ds,+vme -m 8192 -realtime mlock=off -smp 4,sockets=4,cores=1,threads=1 -object memory-backend-file,id=ram-node0,prealloc=yes,mem-path=/mnt/hugepages_1GB/libvirt/qemu,share=yes,size=8589934592,host-nodes=0,policy=bind -numa node,nodeid=0,cpus=0-3,memdev=ram-node0 -uuid 67c02ef1-c6d8-46ed-b9bd-df41eb1cad89 -smbios type=1,manufacturer=OpenStack Foundation,product=OpenStack Nova,version=2015.1.0,serial=5e3ae7d8-b911-4750-add0-0c7d22ed1d9b,uuid=67c02ef1-c6d8-46ed-b9bd-df41eb1cad89 -no-user-config -nodefaults -chardev socket,id=charmonitor,path=/var/lib/libvirt/qemu/domain-instance-00000df0/monitor.sock,server,nowait -mon chardev=charmonitor,id=monitor,mode=control -rtc base=utc,driftfix=slew -global kvm-pit.lost_tick_policy=discard -no-hpet -no-shutdown -boot strict=on -device piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2 -drive file=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/disk,format=qcow2,if=none,id=drive-virtio-disk0,cache=directsync -device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x4,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1 -drive file=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/disk.config,format=raw,if=none,id=drive-ide0-1-1,readonly=on,cache=directsync -device ide-cd,bus=ide.1,unit=1,drive=drive-ide0-1-1,id=ide0-1-1 -netdev tap,ifname=tap0f47cc32-1a,script=,id=hostnet0,vhost=on,vhostfd=26 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=02:0f:47:cc:32:1a,bus=pci.0,addr=0x3 -chardev file,id=charserial0,path=/var/lib/nova/instances/67c02ef1-c6d8-46ed-b9bd-df41eb1cad89/console.log -device isa-serial,chardev=charserial0,id=serial0 -chardev pty,id=charserial1 -device isa-serial,chardev=charserial1,id=serial1 -device usb-tablet,id=input0 -vnc 0.0.0.0:0 -k en-us -device cirrus-vga,id=video0,bus=pci.0,addr=0x2 -device vfio-pci,host=03:17.4,id=hostdev0,bus=pci.0,addr=0x5 -device vfio-pci,host=03:17.5,id=hostdev1,bus=pci.0,addr=0x6 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x7 -msg timestamp=on" | sed -r 's/.+uuid=([[:alnum:]\-]+)[\s,]+.+/\1/g'
```

But the change should work universally whether GNU extension is available.
