### PR TITLE
[plugin/storage] fix bug fix in osd id matching

### DIFF
--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -35,7 +35,7 @@ for svc in ${services[@]}; do
 
         if ((VERBOSITY_LEVEL>=1)); then
             # OSD's Resident memory size
-            osd_RSS=$(get_ps | awk -v id="--id $osd_id" '/ceph-osd/ && $0 ~ id {print int($6/1024)}')
+            osd_RSS=$(get_ps | awk -v id="--id $osd_id " '/ceph-osd/ && $0 ~ id {print int($6/1024); exit}')
             out_str="$out_str (RSS=${osd_RSS}M)"
 
             # OSD's uptime (time since it was started)


### PR DESCRIPTION
Fix a bug in matching osd id's.

The bug was `--id 2` matches with both `--id 24566` as well `--id 2` - only the latter is the correct match. Adding trailing space ensures that.