### PR TITLE
[plugin/kernel] handle error if /proc/slabinfo doesn't exist

### DIFF
--- a/plugins/kernel/01kernel
+++ b/plugins/kernel/01kernel
@@ -53,9 +53,13 @@ get_slab_major_consumers ()
     declare -A top5_name=( [0]= [1]= [2]= [3]= [4]= )
     declare -A top5_num_objs=( [0]=0 [1]=0 [2]=0 [3]=0 [4]=0 )
     declare -A top5_objsize=( [0]= [1]= [2]= [3]= [4]= )
+    local proc_slabinfo="${DATA_ROOT}proc/slabinfo"
+    # /proc/slabinfo may not exist in containers/VMs
+    [[ ! -e "$proc_slabinfo" ]] && return
+
     ftmp=`mktemp`
     # name, num_objs, objsize
-    cat ${DATA_ROOT}proc/slabinfo| tail -n+3| awk '{print $1, $3, $4}'| grep -v kmalloc > $ftmp
+    cat "${proc_slabinfo}"| tail -n+3| awk '{print $1, $3, $4}'| grep -v kmalloc > $ftmp
     while read line; do
         name=`echo $line| cut -d ' ' -f 1`
         num_objs=`echo $line| cut -d ' ' -f 2`


### PR DESCRIPTION
/proc/slabinfo may not exist in containers/VMs.

Fixes #32.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>