### PR TITLE
Report version mismatches and PG imbalances

### DIFF
--- a/helpers
+++ b/helpers
@@ -149,6 +149,17 @@ get_ceph_osd_df_tree ()
 }
 export -f get_ceph_osd_df_tree
 
+get_ceph_versions ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/ceph/ceph_versions"
+    if [ -e "$sos_path" ]; then
+        cat $sos_path
+    elif ! [ -d "${DATA_ROOT}sos_commands" ] && which ceph >/dev/null; then
+        ceph versions
+    fi  
+}
+export -f get_ceph_versions
+
 get_dpkg_l ()
 {
     local sos_path=${DATA_ROOT}sos_commands/dpkg/dpkg_-l

--- a/helpers
+++ b/helpers
@@ -138,6 +138,17 @@ get_ceph_osd_tree ()
 }
 export -f get_ceph_osd_tree
 
+get_ceph_osd_df_tree ()
+{
+    local sos_path="${DATA_ROOT}/sos_commands/ceph/ceph_osd_df_tree"
+    if [ -e "$sos_path" ]; then
+        cat $sos_path
+    elif ! [ -d "${DATA_ROOT}sos_commands" ] && which ceph >/dev/null; then
+        ceph osd df tree
+    fi
+}
+export -f get_ceph_osd_df_tree
+
 get_dpkg_l ()
 {
     local sos_path=${DATA_ROOT}sos_commands/dpkg/dpkg_-l

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -1,6 +1,17 @@
 #!/bin/bash -u
 # This plugin displays information about Ceph.
 
+ceph_pg_imbalance ()
+{
+    # upstream recommends 50-100 OSDs ideally.
+    local bad_pgs=$(get_ceph_osd_df_tree | awk '$NF ~ "^osd."{ pg=$(NF-1); if (pg > 0 && (pg < 50 || pg > 120)) printf "%s ", pg }')
+
+    if [[ -n $bad_pgs ]]; then
+        echo "ceph-pgs: Found OSDs with pg counts [$bad_pgs]. Recommended range is 50 - 100."
+    fi
+}
+
+
 declare -a output=()
 services=(
     ceph-osd
@@ -57,6 +68,9 @@ for svc in ${services[@]}; do
         output+=( "$out_str" )
     done
 done
+
+pgs_imbalanced="$(ceph_pg_imbalance)"
+[[ -n $pgs_imbalanced ]] && output+=( "$pgs_imbalanced" )
 
 if ((${#output[@]})); then
     for line in "${output[@]}"; do

--- a/plugins/storage/01ceph
+++ b/plugins/storage/01ceph
@@ -7,7 +7,16 @@ ceph_pg_imbalance ()
     local bad_pgs=$(get_ceph_osd_df_tree | awk '$NF ~ "^osd."{ pg=$(NF-1); if (pg > 0 && (pg < 50 || pg > 120)) printf "%s ", pg }')
 
     if [[ -n $bad_pgs ]]; then
-        echo "ceph-pgs: Found OSDs with pg counts [$bad_pgs]. Recommended range is 50 - 100."
+        echo "ceph-pgs: WARNING! Found OSDs with pg counts [$bad_pgs]. Recommended range is 50 - 100."
+    fi
+}
+
+ceph_versions_mismatch ()
+{
+    # Check versions of all running daemons are the same.
+    local count=$(get_ceph_versions | awk -F' ' '/ceph version/{arr[$3]=1}END{ print length(arr)}')
+    if [[ $count > 1 ]]; then
+        echo "ceph-versions: WARNING! Found multiple ($count different) versions of daemons running."
     fi
 }
 
@@ -71,6 +80,9 @@ done
 
 pgs_imbalanced="$(ceph_pg_imbalance)"
 [[ -n $pgs_imbalanced ]] && output+=( "$pgs_imbalanced" )
+
+vers="$(ceph_versions_mismatch)"
+[[ -n $vers ]] && output+=( "$vers" )
 
 if ((${#output[@]})); then
     for line in "${output[@]}"; do


### PR DESCRIPTION

1. Report PGs imbalance.Upstream recommends 50 - 100 PGs per OSD [0].

2. Report if Ceph daemons' versions are not the same.

Fixes #34.
Fixes #35.

[0] https://docs.ceph.com/en/latest/rados/operations/placement-groups/