### PR TITLE
[juju] Add 04known_bugs

### DIFF
--- a/common/helpers.sh
+++ b/common/helpers.sh
@@ -145,7 +145,7 @@ get_ceph_versions ()
         cat $sos_path
     elif ! [ -d "${DATA_ROOT}sos_commands" ] && which ceph >/dev/null; then
         ceph versions
-    fi  
+    fi
 }
 export -f get_ceph_versions
 

--- a/common/known_bugs_utils.py
+++ b/common/known_bugs_utils.py
@@ -47,7 +47,8 @@ def add_known_bug(bug_id, description=None, type=LAUNCHPAD):
 
     current = _get_known_bugs()
     if current and current.get(MASTER_YAML_KNOWN_BUGS_KEY):
-        current[MASTER_YAML_KNOWN_BUGS_KEY].append(entry)
+        if entry not in current.get(MASTER_YAML_KNOWN_BUGS_KEY):
+            current[MASTER_YAML_KNOWN_BUGS_KEY].append(entry)
     else:
         current = {MASTER_YAML_KNOWN_BUGS_KEY: [entry]}
 

--- a/common/searchtools.py
+++ b/common/searchtools.py
@@ -138,9 +138,7 @@ class FileSearcher(object):
 
     def _search_task(self, term_key, fd, path):
         results = []
-        for ln, line in enumerate(fd):
-            # line numbers are not zero-indexed
-            ln += 1
+        for ln, line in enumerate(fd, start=1):
             for s_term in self.paths[term_key]:
                 if type(line) == bytes:
                     line = line.decode("utf-8")
@@ -153,7 +151,12 @@ class FileSearcher(object):
                 ret = s_term["key"].match(line)
                 if ret:
                     r = SearchResult(ln, path, s_term.get("tag"))
+                    # ensure we always add this
+                    r.add(0, ret[0])
                     for i in s_term["indices"]:
+                        if i == 0:
+                            continue
+
                         r.add(i, ret[i])
 
                     results.append(r)

--- a/plugins/juju/04known_bugs
+++ b/plugins/juju/04known_bugs
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+from common import searchtools
+from common.known_bugs_utils import add_known_bug
+from juju_common import (
+    JUJU_LOG_PATH
+)
+
+# maximum number of chars to print when a matching text is detected.
+MAX_MATCH_CHARS = 200
+
+
+def detect_known_bugs():
+    """Unit fails to start complaining there are members in the relation."""
+    known_bugs = {
+        1910958: {
+            "description": ("Unit fails to start complaining there are "
+                            "members in the relation."),
+            "pattern": (
+                r'.* manifold worker returned unexpected error: failed to '
+                r'initialize uniter for "[A-Za-z0-9-]+": cannot create '
+                r'relation state tracker: cannot remove persisted state, '
+                r'relation \d+ has members')
+            }
+        }
+
+    s = searchtools.FileSearcher()
+    for bug in known_bugs:
+        s.add_search_term(known_bugs[bug]["pattern"], [],
+                          f"{JUJU_LOG_PATH}/*", tag=bug)
+
+    results = s.search()
+
+    for bug in known_bugs:
+        if results.find_by_tag(bug):
+            add_known_bug(bug, known_bugs.get("description"))
+
+
+if __name__ == "__main__":
+    detect_known_bugs()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ mock
 nose
 pylint
 testtools
+rpdb

--- a/tests/unit/fake_data_root/var/log/juju/unit-rabbitmq-server-2.log
+++ b/tests/unit/fake_data_root/var/log/juju/unit-rabbitmq-server-2.log
@@ -1,0 +1,2 @@
+2021-02-17 08:18:44 ERROR juju.worker.dependency engine.go:671 "uniter" manifold worker returned unexpected error: failed to initialize uniter for "unit-rabbitmq-server-2": cannot create relation state tracker: cannot remove persisted state, relation 236 has members
+2021-02-17 08:20:34 ERROR juju.worker.dependency engine.go:671 "uniter" manifold worker returned unexpected error: failed to initialize uniter for "unit-rabbitmq-server-2": cannot create relation state tracker: cannot remove persisted state, relation 236 has members

--- a/tests/unit/fake_data_root/var/log/juju/unit-rabbitmq-server-3.log
+++ b/tests/unit/fake_data_root/var/log/juju/unit-rabbitmq-server-3.log
@@ -1,0 +1,2 @@
+2021-02-17 08:18:44 ERROR juju.worker.dependency engine.go:671 "uniter" manifold worker returned unexpected error: failed to initialize uniter for "unit-rabbitmq-server-2": cannot create relation state tracker: cannot remove persisted state, relation 236 has members
+2021-02-17 08:20:34 ERROR juju.worker.dependency engine.go:671 "uniter" manifold worker returned unexpected error: failed to initialize uniter for "unit-rabbitmq-server-2": cannot create relation state tracker: cannot remove persisted state, relation 236 has members


### PR DESCRIPTION
This is a new plugin meant to detect known bugs, this first version is
capable of detecting possible occurrences of LP: #1910958

Example output:

```
$ /home/freyes/Projects/hotsos/hotsos.sh --juju ./
hotsos:
  version: development
  repo-info: 50beab7
...
juju:
  machines:
    running:
      - 31 (version=unknown)
  charm-versions:
    - filebeat-33
    ...
    stopped:
      - rabbitmq-server-3
  - bug: 'LP: #1910958'
    description: Unit fails to start complaining there are members in the relation.
    files_with_matches:
      - ./var/log/juju/unit-rabbitmq-server-3.log
      - ./var/log/juju/unit-rabbitmq-server-2.log

INFO: see --help for more display options
```