### PR TITLE
Clean up tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = pep8,pylint,py36,py38
+envlist = pep8,pylint,py3
 sitepackages = False
 
 [gh-actions]
@@ -21,23 +21,16 @@ deps =
     -r{toxinidir}/test-requirements.txt
 commands = nosetests {posargs} {toxinidir}/tests/unit
 
-[testenv:py36]
-basepython = python3.6
-
-[testenv:py38]
-basepython = python3.8
-
 [testenv:pep8]
-basepython = python3.8
+basepython = python3
 commands = {toxinidir}/tools/test/run_flake8.sh \
            {toxinidir}/common \
            {toxinidir}/plugins \
            {toxinidir}/tests/unit
 
 [testenv:pylint]
-basepython = python3.8
+basepython = python3
 commands = {toxinidir}/tools/test/run_pylint.sh \
            {toxinidir}/common \
            {toxinidir}/plugins \
            {toxinidir}/tests/unit
-


### PR DESCRIPTION
The `py??` environments are implicit and default to the select Python
version. This change also removes the `basepython` setting for the
`pep8` and `pylint` environments. These tests should work for any
Python version.

Closes: dosaboy/hotsos#56

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>