### PR TITLE
Storage: add check for ceph crush map's mixed items buckets

### DIFF
--- a/common/helpers.py
+++ b/common/helpers.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+import json
 
 # HOTSOS GLOBALS
 DATA_ROOT = os.environ.get('DATA_ROOT', '/')
@@ -189,6 +190,19 @@ def get_snap_list_all():
         return open(path, 'r').readlines()
 
     return []
+
+
+@catch_exceptions(OSError, subprocess.CalledProcessError, json.JSONDecodeError)
+def get_osd_crush_dump():
+    if DATA_ROOT == "/":
+        output = subprocess.check_output(['ceph', 'osd', 'crush', 'dump'])
+        return json.loads(output.decode('UTF-8'))
+
+    path = os.path.join(DATA_ROOT, "sos_commands/ceph/ceph_osd_crush_dump")
+    if os.path.exists(path):
+        f = open(path)
+        return json.load(f)
+    return {}
 
 
 @catch_exceptions(OSError, subprocess.CalledProcessError)

--- a/tests/unit/fake_data_root/sos_commands/ceph/ceph_osd_crush_dump
+++ b/tests/unit/fake_data_root/sos_commands/ceph/ceph_osd_crush_dump
@@ -1,0 +1,1903 @@
+{
+    "devices": [
+        {
+            "id": 0,
+            "name": "osd.0",
+            "class": "ssd"
+        },
+        {
+            "id": 1,
+            "name": "osd.1",
+            "class": "ssd"
+        },
+        {
+            "id": 2,
+            "name": "osd.2",
+            "class": "ssd"
+        },
+        {
+            "id": 3,
+            "name": "osd.3",
+            "class": "ssd"
+        },
+        {
+            "id": 4,
+            "name": "osd.4",
+            "class": "ssd"
+        },
+        {
+            "id": 5,
+            "name": "osd.5",
+            "class": "ssd"
+        },
+        {
+            "id": 6,
+            "name": "osd.6",
+            "class": "ssd"
+        },
+        {
+            "id": 7,
+            "name": "osd.7",
+            "class": "ssd"
+        },
+        {
+            "id": 8,
+            "name": "osd.8",
+            "class": "ssd"
+        },
+        {
+            "id": 9,
+            "name": "osd.9",
+            "class": "ssd"
+        },
+        {
+            "id": 10,
+            "name": "osd.10",
+            "class": "ssd"
+        },
+        {
+            "id": 11,
+            "name": "osd.11",
+            "class": "ssd"
+        },
+        {
+            "id": 12,
+            "name": "osd.12",
+            "class": "ssd"
+        },
+        {
+            "id": 13,
+            "name": "osd.13",
+            "class": "ssd"
+        },
+        {
+            "id": 14,
+            "name": "osd.14",
+            "class": "ssd"
+        },
+        {
+            "id": 15,
+            "name": "osd.15",
+            "class": "ssd"
+        },
+        {
+            "id": 16,
+            "name": "osd.16",
+            "class": "ssd"
+        },
+        {
+            "id": 17,
+            "name": "osd.17",
+            "class": "ssd"
+        },
+        {
+            "id": 18,
+            "name": "osd.18",
+            "class": "ssd"
+        },
+        {
+            "id": 19,
+            "name": "osd.19",
+            "class": "ssd"
+        },
+        {
+            "id": 20,
+            "name": "osd.20",
+            "class": "ssd"
+        },
+        {
+            "id": 21,
+            "name": "osd.21",
+            "class": "ssd"
+        },
+        {
+            "id": 22,
+            "name": "osd.22",
+            "class": "ssd"
+        },
+        {
+            "id": 23,
+            "name": "osd.23",
+            "class": "ssd"
+        },
+        {
+            "id": 24,
+            "name": "osd.24",
+            "class": "ssd"
+        },
+        {
+            "id": 25,
+            "name": "osd.25",
+            "class": "ssd"
+        },
+        {
+            "id": 26,
+            "name": "osd.26",
+            "class": "ssd"
+        },
+        {
+            "id": 27,
+            "name": "osd.27",
+            "class": "ssd"
+        },
+        {
+            "id": 28,
+            "name": "osd.28",
+            "class": "ssd"
+        },
+        {
+            "id": 29,
+            "name": "osd.29",
+            "class": "ssd"
+        },
+        {
+            "id": 30,
+            "name": "osd.30",
+            "class": "ssd"
+        },
+        {
+            "id": 31,
+            "name": "osd.31",
+            "class": "ssd"
+        },
+        {
+            "id": 32,
+            "name": "osd.32",
+            "class": "ssd"
+        },
+        {
+            "id": 33,
+            "name": "osd.33",
+            "class": "ssd"
+        },
+        {
+            "id": 34,
+            "name": "osd.34",
+            "class": "ssd"
+        },
+        {
+            "id": 35,
+            "name": "osd.35",
+            "class": "ssd"
+        },
+        {
+            "id": 36,
+            "name": "osd.36",
+            "class": "ssd"
+        },
+        {
+            "id": 37,
+            "name": "osd.37",
+            "class": "ssd"
+        },
+        {
+            "id": 38,
+            "name": "osd.38",
+            "class": "ssd"
+        },
+        {
+            "id": 39,
+            "name": "osd.39",
+            "class": "ssd"
+        },
+        {
+            "id": 40,
+            "name": "osd.40",
+            "class": "ssd"
+        },
+        {
+            "id": 41,
+            "name": "osd.41",
+            "class": "ssd"
+        },
+        {
+            "id": 42,
+            "name": "osd.42",
+            "class": "ssd"
+        },
+        {
+            "id": 43,
+            "name": "osd.43",
+            "class": "ssd"
+        },
+        {
+            "id": 44,
+            "name": "osd.44",
+            "class": "ssd"
+        },
+        {
+            "id": 45,
+            "name": "osd.45",
+            "class": "ssd"
+        },
+        {
+            "id": 46,
+            "name": "osd.46",
+            "class": "ssd"
+        },
+        {
+            "id": 47,
+            "name": "osd.47",
+            "class": "ssd"
+        },
+        {
+            "id": 48,
+            "name": "osd.48",
+            "class": "ssd"
+        },
+        {
+            "id": 49,
+            "name": "osd.49",
+            "class": "ssd"
+        },
+        {
+            "id": 50,
+            "name": "osd.50",
+            "class": "ssd"
+        },
+        {
+            "id": 51,
+            "name": "osd.51",
+            "class": "ssd"
+        },
+        {
+            "id": 52,
+            "name": "osd.52",
+            "class": "ssd"
+        },
+        {
+            "id": 53,
+            "name": "osd.53",
+            "class": "ssd"
+        },
+        {
+            "id": 54,
+            "name": "osd.54",
+            "class": "ssd"
+        },
+        {
+            "id": 55,
+            "name": "osd.55",
+            "class": "ssd"
+        },
+        {
+            "id": 56,
+            "name": "osd.56",
+            "class": "ssd"
+        },
+        {
+            "id": 57,
+            "name": "osd.57",
+            "class": "ssd"
+        },
+        {
+            "id": 58,
+            "name": "osd.58",
+            "class": "ssd"
+        },
+        {
+            "id": 59,
+            "name": "osd.59",
+            "class": "ssd"
+        },
+        {
+            "id": 60,
+            "name": "osd.60",
+            "class": "ssd"
+        },
+        {
+            "id": 61,
+            "name": "osd.61",
+            "class": "ssd"
+        },
+        {
+            "id": 62,
+            "name": "osd.62",
+            "class": "ssd"
+        },
+        {
+            "id": 63,
+            "name": "osd.63",
+            "class": "ssd"
+        },
+        {
+            "id": 64,
+            "name": "osd.64",
+            "class": "ssd"
+        },
+        {
+            "id": 65,
+            "name": "osd.65",
+            "class": "ssd"
+        },
+        {
+            "id": 66,
+            "name": "osd.66",
+            "class": "ssd"
+        },
+        {
+            "id": 67,
+            "name": "osd.67",
+            "class": "ssd"
+        },
+        {
+            "id": 68,
+            "name": "osd.68",
+            "class": "ssd"
+        },
+        {
+            "id": 69,
+            "name": "osd.69",
+            "class": "ssd"
+        },
+        {
+            "id": 70,
+            "name": "osd.70",
+            "class": "ssd"
+        },
+        {
+            "id": 71,
+            "name": "osd.71",
+            "class": "ssd"
+        },
+        {
+            "id": 72,
+            "name": "osd.72",
+            "class": "ssd"
+        },
+        {
+            "id": 73,
+            "name": "osd.73",
+            "class": "ssd"
+        },
+        {
+            "id": 74,
+            "name": "osd.74",
+            "class": "ssd"
+        },
+        {
+            "id": 75,
+            "name": "osd.75",
+            "class": "ssd"
+        }
+    ],
+    "types": [
+        {
+            "type_id": 0,
+            "name": "osd"
+        },
+        {
+            "type_id": 1,
+            "name": "host"
+        },
+        {
+            "type_id": 2,
+            "name": "chassis"
+        },
+        {
+            "type_id": 3,
+            "name": "rack"
+        },
+        {
+            "type_id": 4,
+            "name": "row"
+        },
+        {
+            "type_id": 5,
+            "name": "pdu"
+        },
+        {
+            "type_id": 6,
+            "name": "pod"
+        },
+        {
+            "type_id": 7,
+            "name": "room"
+        },
+        {
+            "type_id": 8,
+            "name": "datacenter"
+        },
+        {
+            "type_id": 9,
+            "name": "region"
+        },
+        {
+            "type_id": 10,
+            "name": "root"
+        }
+    ],
+    "buckets": [
+        {
+            "id": -1,
+            "name": "default",
+            "type_id": 10,
+            "type_name": "root",
+            "weight": 18121142,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -3,
+                    "weight": 953745,
+                    "pos": 0
+                },
+                {
+                    "id": -5,
+                    "weight": 953745,
+                    "pos": 1
+                },
+                {
+                    "id": -7,
+                    "weight": 953745,
+                    "pos": 2
+                },
+                {
+                    "id": -9,
+                    "weight": 953745,
+                    "pos": 3
+                },
+                {
+                    "id": -11,
+                    "weight": 953745,
+                    "pos": 4
+                },
+                {
+                    "id": -13,
+                    "weight": 953745,
+                    "pos": 5
+                },
+                {
+                    "id": -15,
+                    "weight": 953745,
+                    "pos": 6
+                },
+                {
+                    "id": -17,
+                    "weight": 953745,
+                    "pos": 7
+                },
+                {
+                    "id": -19,
+                    "weight": 953745,
+                    "pos": 8
+                },
+                {
+                    "id": -21,
+                    "weight": 953745,
+                    "pos": 9
+                },
+                {
+                    "id": -23,
+                    "weight": 953745,
+                    "pos": 10
+                },
+                {
+                    "id": -25,
+                    "weight": 953745,
+                    "pos": 11
+                },
+                {
+                    "id": -27,
+                    "weight": 953745,
+                    "pos": 12
+                },
+                {
+                    "id": -29,
+                    "weight": 953745,
+                    "pos": 13
+                },
+                {
+                    "id": -33,
+                    "weight": 953745,
+                    "pos": 14
+                },
+                {
+                    "id": -35,
+                    "weight": 953745,
+                    "pos": 15
+                },
+                {
+                    "id": -37,
+                    "weight": 953745,
+                    "pos": 16
+                },
+                {
+                    "id": -39,
+                    "weight": 953745,
+                    "pos": 17
+                },
+                {
+                    "id": -32,
+                    "weight": 953732,
+                    "pos": 18
+                }
+            ]
+        },
+        {
+            "id": -2,
+            "name": "default~ssd",
+            "type_id": 10,
+            "type_name": "root",
+            "weight": 18119900,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -4,
+                    "weight": 953676,
+                    "pos": 0
+                },
+                {
+                    "id": -6,
+                    "weight": 953676,
+                    "pos": 1
+                },
+                {
+                    "id": -8,
+                    "weight": 953676,
+                    "pos": 2
+                },
+                {
+                    "id": -10,
+                    "weight": 953676,
+                    "pos": 3
+                },
+                {
+                    "id": -12,
+                    "weight": 953676,
+                    "pos": 4
+                },
+                {
+                    "id": -14,
+                    "weight": 953676,
+                    "pos": 5
+                },
+                {
+                    "id": -16,
+                    "weight": 953676,
+                    "pos": 6
+                },
+                {
+                    "id": -18,
+                    "weight": 953676,
+                    "pos": 7
+                },
+                {
+                    "id": -20,
+                    "weight": 953676,
+                    "pos": 8
+                },
+                {
+                    "id": -22,
+                    "weight": 953676,
+                    "pos": 9
+                },
+                {
+                    "id": -24,
+                    "weight": 953676,
+                    "pos": 10
+                },
+                {
+                    "id": -26,
+                    "weight": 953676,
+                    "pos": 11
+                },
+                {
+                    "id": -28,
+                    "weight": 953676,
+                    "pos": 12
+                },
+                {
+                    "id": -30,
+                    "weight": 953676,
+                    "pos": 13
+                },
+                {
+                    "id": -34,
+                    "weight": 953676,
+                    "pos": 14
+                },
+                {
+                    "id": -36,
+                    "weight": 953676,
+                    "pos": 15
+                },
+                {
+                    "id": -38,
+                    "weight": 953676,
+                    "pos": 16
+                },
+                {
+                    "id": -40,
+                    "weight": 953676,
+                    "pos": 17
+                },
+                {
+                    "id": -42,
+                    "weight": 953732,
+                    "pos": 18
+                }
+            ]
+        },
+        {
+            "id": -3,
+            "name": "t1-bits-cloud-hci006",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 0,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 7,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 26,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 45,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -4,
+            "name": "t1-bits-cloud-hci006~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 0,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 7,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 26,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 45,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -5,
+            "name": "t1-bits-cloud-hci016",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 1,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 10,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 32,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 51,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -6,
+            "name": "t1-bits-cloud-hci016~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 1,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 10,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 32,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 51,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -7,
+            "name": "t1-bits-cloud-hci017",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 2,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 8,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 27,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 46,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -8,
+            "name": "t1-bits-cloud-hci017~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 2,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 8,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 27,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 46,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -9,
+            "name": "t1-bits-cloud-hci007",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 3,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 9,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 28,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 48,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -10,
+            "name": "t1-bits-cloud-hci007~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 3,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 9,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 28,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 48,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -11,
+            "name": "t1-bits-cloud-hci019",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 5,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 13,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 31,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 50,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -12,
+            "name": "t1-bits-cloud-hci019~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 5,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 13,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 31,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 50,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -13,
+            "name": "t1-bits-cloud-hci013",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 6,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 11,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 29,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 47,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -14,
+            "name": "t1-bits-cloud-hci013~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 6,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 11,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 29,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 47,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -15,
+            "name": "t1-bits-cloud-hci018",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 4,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 12,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 30,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 49,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -16,
+            "name": "t1-bits-cloud-hci018~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 4,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 12,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 30,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 49,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -17,
+            "name": "t1-bits-cloud-hci012",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 14,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 33,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 52,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 64,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -18,
+            "name": "t1-bits-cloud-hci012~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 14,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 33,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 52,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 64,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -19,
+            "name": "t1-bits-cloud-hci001",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 15,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 35,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 54,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 68,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -20,
+            "name": "t1-bits-cloud-hci001~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 15,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 35,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 54,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 68,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -21,
+            "name": "t1-bits-cloud-hci005",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 16,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 34,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 53,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 65,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -22,
+            "name": "t1-bits-cloud-hci005~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 16,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 34,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 53,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 65,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -23,
+            "name": "t1-bits-cloud-hci004",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 18,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 37,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 56,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 67,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -24,
+            "name": "t1-bits-cloud-hci004~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 18,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 37,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 56,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 67,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -25,
+            "name": "t1-bits-cloud-hci011",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 17,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 36,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 55,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 66,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -26,
+            "name": "t1-bits-cloud-hci011~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 17,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 36,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 55,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 66,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -27,
+            "name": "t1-bits-cloud-hci014",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 24,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 38,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 57,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 69,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -28,
+            "name": "t1-bits-cloud-hci014~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 24,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 38,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 57,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 69,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -29,
+            "name": "t1-bits-cloud-hci010",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 21,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 39,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 58,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 70,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -30,
+            "name": "t1-bits-cloud-hci010~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 21,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 39,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 58,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 70,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -31,
+            "name": "t1-bits-cloud-hci015",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953732,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 22,
+                    "weight": 238433,
+                    "pos": 0
+                },
+                {
+                    "id": 42,
+                    "weight": 238433,
+                    "pos": 1
+                },
+                {
+                    "id": 61,
+                    "weight": 238433,
+                    "pos": 2
+                },
+                {
+                    "id": 74,
+                    "weight": 238433,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -32,
+            "name": "04-06",
+            "type_id": 3,
+            "type_name": "rack",
+            "weight": 953732,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -31,
+                    "weight": 953732,
+                    "pos": 0
+                }
+            ]
+        },
+        {
+            "id": -33,
+            "name": "t1-bits-cloud-hci020",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 25,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 40,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 59,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 71,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -34,
+            "name": "t1-bits-cloud-hci020~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 25,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 40,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 59,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 71,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -35,
+            "name": "t1-bits-cloud-hci008",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 19,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 43,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 62,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 73,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -36,
+            "name": "t1-bits-cloud-hci008~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 19,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 43,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 62,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 73,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -37,
+            "name": "t1-bits-cloud-hci002",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 23,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 44,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 63,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 75,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -38,
+            "name": "t1-bits-cloud-hci002~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 23,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 44,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 63,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 75,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -39,
+            "name": "t1-bits-cloud-hci009",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 20,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 41,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 60,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 72,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -40,
+            "name": "t1-bits-cloud-hci009~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953676,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 20,
+                    "weight": 238419,
+                    "pos": 0
+                },
+                {
+                    "id": 41,
+                    "weight": 238419,
+                    "pos": 1
+                },
+                {
+                    "id": 60,
+                    "weight": 238419,
+                    "pos": 2
+                },
+                {
+                    "id": 72,
+                    "weight": 238419,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -41,
+            "name": "t1-bits-cloud-hci015~ssd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 953732,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 22,
+                    "weight": 238433,
+                    "pos": 0
+                },
+                {
+                    "id": 42,
+                    "weight": 238433,
+                    "pos": 1
+                },
+                {
+                    "id": 61,
+                    "weight": 238433,
+                    "pos": 2
+                },
+                {
+                    "id": 74,
+                    "weight": 238433,
+                    "pos": 3
+                }
+            ]
+        },
+        {
+            "id": -42,
+            "name": "04-06~ssd",
+            "type_id": 3,
+            "type_name": "rack",
+            "weight": 953732,
+            "alg": "straw2",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -41,
+                    "weight": 953732,
+                    "pos": 0
+                }
+            ]
+        }
+    ],
+    "rules": [
+        {
+            "rule_id": 0,
+            "rule_name": "replicated_rule",
+            "ruleset": 0,
+            "type": 1,
+            "min_size": 1,
+            "max_size": 10,
+            "steps": [
+                {
+                    "op": "take",
+                    "item": -1,
+                    "item_name": "default"
+                },
+                {
+                    "op": "chooseleaf_firstn",
+                    "num": 0,
+                    "type": "rack"
+                },
+                {
+                    "op": "emit"
+                }
+            ]
+        }
+    ],
+    "tunables": {
+        "choose_local_tries": 0,
+        "choose_local_fallback_tries": 0,
+        "choose_total_tries": 50,
+        "chooseleaf_descend_once": 1,
+        "chooseleaf_vary_r": 1,
+        "chooseleaf_stable": 1,
+        "straw_calc_version": 1,
+        "allowed_bucket_algs": 54,
+        "profile": "jewel",
+        "optimal_tunables": 1,
+        "legacy_tunables": 0,
+        "minimum_required_version": "jewel",
+        "require_feature_tunables": 1,
+        "require_feature_tunables2": 1,
+        "has_v2_rules": 0,
+        "require_feature_tunables3": 1,
+        "has_v3_rules": 0,
+        "has_v4_buckets": 1,
+        "require_feature_tunables5": 1,
+        "has_v5_rules": 0
+    },
+    "choose_args": {}
+}
+

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -54,6 +54,12 @@ class TestStoragePlugin01ceph(utils.BaseTestCase):
         self.assertFalse("services" in _01ceph.CEPH_INFO)
 
     @mock.patch.object(_01ceph, "CEPH_INFO", {})
+    def test_get_crushmap_mixed_buckets(self):
+        _01ceph.get_ceph_checker()()
+        result = ['default', 'default~ssd']
+        self.assertEqual(_01ceph.CEPH_INFO["mixed_crush_buckets"], result)
+
+    @mock.patch.object(_01ceph, "CEPH_INFO", {})
     def test_get_ceph_versions_mismatch(self):
         result = {'mgr': ['14.2.11'],
                   'mon': ['14.2.11'],


### PR DESCRIPTION
This patch will make hotsos able to report those crush buckets that contains mixed items.
mixed items bucket is always a problem which would cause ceph unable to recover