### PR TITLE
kubernetes snaps not listed

### DIFF
--- a/common/helpers.py
+++ b/common/helpers.py
@@ -185,9 +185,14 @@ def get_snap_list_all():
         output = subprocess.check_output(['snap', 'list', '--all'])
         return output.decode('UTF-8').splitlines(keepends=True)
 
-    path = os.path.join(DATA_ROOT, "sos_commands/snappy/snap_list_--all")
+    path = os.path.join(DATA_ROOT, "sos_commands/snap/snap_list_--all")
+    # sos_commands/snappy is not present in new sos reports as snappy plugin
+    # is renamed.
+    old_path = os.path.join(DATA_ROOT, "sos_commands/snappy/snap_list_--all")
     if os.path.exists(path):
         return open(path, 'r').readlines()
+    elif os.path.exists(old_path):
+        return open(old_path, 'r').readlines()
 
     return []
 

--- a/plugins/kubernetes/_01general.py
+++ b/plugins/kubernetes/_01general.py
@@ -19,6 +19,7 @@ SERVICES = ["etcdctl",
             "dockerd",
             "kubelet",
             "kube-proxy",
+            "calico-node",
             ]
 
 # Snaps that only exist in a K8s deployment
@@ -27,7 +28,7 @@ SNAPS_K8S = [r'charm[\S]+',
              r'cdk-addons',
              r'helm',
              r'kubernetes-[\S]+',
-             r'kube-proxy',
+             r'kube-[\S]+',
              r'kubectl',
              r'kubelet',
              r'kubeadm',

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -21,7 +21,8 @@ class TestKubernetesPlugin01general(utils.BaseTestCase):
 
     @mock.patch.object(_01general, "KUBERNETES_INFO", {})
     def test_get_service_info(self):
-        expected = {'services': ['containerd (17)',
+        expected = {'services': ['calico-node (3)',
+                                 'containerd (17)',
                                  'containerd-shim (16)',
                                  'flanneld (1)',
                                  'kube-proxy (1)',


### PR DESCRIPTION
Following changes are done
- Corrected the path of snap list in sosreport
- Added kube-* to list of snaps
- Added calico-node to list of services