### PR TITLE
Quote `SOS_PATHS`

### DIFF
--- a/hotsos.sh
+++ b/hotsos.sh
@@ -183,7 +183,7 @@ while (($#)); do
             done
             if ! $plugin_provided; then
                 [[ -d $1 ]] || { echo "ERROR: invalid path or option '$1'"; exit 1; }
-                SOS_PATHS+=( $1 )
+                SOS_PATHS+=( "$1" )
             fi
             ;;
     esac
@@ -233,7 +233,7 @@ run_part ()
 }
 
 CWD=$(dirname `realpath $0`)
-for data_root in ${SOS_PATHS[@]}; do
+for data_root in "${SOS_PATHS[@]}"; do
     if [ "$data_root" = "/" ]; then
         echo -e "INFO: analysing localhost since no sosreport path provided\n" 1>&2
         DATA_ROOT=/


### PR DESCRIPTION
In case the path contains a whitespace, the `SOS_PATHS` variable needs
to be quoted.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>