### PR TITLE
Add bashate check to `tox`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,3 +30,6 @@ jobs:
     - name: Run pep8
       run: tox -e pep8
       if: matrix.python-version == 3.9
+    - name: Run bashate
+      run: tox -e bashate
+      if: matrix.python-version == 3.9

--- a/hotsos.sh
+++ b/hotsos.sh
@@ -284,7 +284,7 @@ for data_root in ${SOS_PATHS[@]}; do
     if [[ -n ${REPO_INFO_PATH:-""} ]] && [[ -r $REPO_INFO_PATH ]]; then
         repo_info=`cat $REPO_INFO_PATH`
     else
-        repo_info=`get_git_rev_info` || repo_info="unknown" 
+        repo_info=`get_git_rev_info` || repo_info="unknown"
     fi
     echo -e "hotsos:\n  version: ${SNAP_REVISION:-"development"}\n  repo-info: $repo_info" > $MASTER_YAML_OUT
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
+bashate
 flake8
 mock
 nose
 pylint
-testtools
 rpdb
+testtools

--- a/tools/test/run_bashate.sh
+++ b/tools/test/run_bashate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e -u
+
+bashate --verbose $(git ls-files \*.sh)

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,7 @@ commands = {toxinidir}/tools/test/run_pylint.sh \
            {toxinidir}/plugins \
            {toxinidir}/tools \
            {toxinidir}/tests/unit
+
+[testenv:bashate]
+basepython = python3
+commands = {toxinidir}/tools/test/run_bashate.sh


### PR DESCRIPTION
So that the shell scripts are linted as well.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>