### PR TITLE
Add RabbitMQ issue for severely imbalanced clusters

### DIFF
--- a/common/issue_types.py
+++ b/common/issue_types.py
@@ -26,3 +26,7 @@ class NeutronL3HAWarning(IssueTypeBase):
 
 class NetworkWarning(IssueTypeBase):
     pass
+
+
+class RabbitMQWarning(IssueTypeBase):
+    pass

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -164,6 +164,7 @@ class TestOpenstackPluginPartPackage_info(utils.BaseTestCase):
             'libvirt-daemon 4.0.0-1ubuntu8.15~cloud0',
             'libvirt-daemon-driver-storage-rbd 4.0.0-1ubuntu8.15~cloud0',
             'libvirt-daemon-system 4.0.0-1ubuntu8.15~cloud0',
+            'mysql-common 5.7.33-0ubuntu0.16.04.1',
             'neutron-common 2:12.1.0-0ubuntu1~cloud0',
             'neutron-dhcp-agent 2:12.1.0-0ubuntu1~cloud0',
             'neutron-l3-agent 2:12.1.0-0ubuntu1~cloud0',

--- a/tests/unit/test_rabbitmq.py
+++ b/tests/unit/test_rabbitmq.py
@@ -59,7 +59,6 @@ class TestRabbitmqPluginPartServices(utils.BaseTestCase):
                                self.tmpdir):
             services.get_rabbitmq_service_checker()()
             issues = services.issues_utils._get_issues()
-        self.maxDiff = None
         self.assertEqual(services.RABBITMQ_INFO, expected)
         self.assertEqual(issues,
                          {services.issues_utils.MASTER_YAML_ISSUES_FOUND_KEY:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -48,6 +48,6 @@ class TestTools(utils.BaseTestCase):
                 output_filter.filter_master_yaml()
 
                 with open(ftmp.name) as fd:
-                    result = yaml.load(fd)
+                    result = yaml.load(fd, Loader=yaml.SafeLoader)
 
                 self.assertEqual(result, expected)


### PR DESCRIPTION
If one broker holds more than 2/3 of all queues raise an issue. The
threshold of 2/3 is somewhat arbitrary but a cluster that is this
imbalanced might experience some load bottle necks.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>