### PR TITLE
Do not fail on invalid logfile name

### DIFF
--- a/common/searchtools.py
+++ b/common/searchtools.py
@@ -474,7 +474,12 @@ class FileSearcher(object):
             except ValueError:
                 return 0
 
-        return int(idx)
+        try:
+            int_idx = int(idx)
+        except ValueError:
+            return 0
+
+        return int_idx
 
     def search(self):
         """Execute all the search queries.


### PR DESCRIPTION
The searchtool assumes that logfiles follow a standard naming
convention and are rotated using logrotate with standard numbering. If
we encounter a sosreport that contains additional logfiles that do not
fit this pattern, e.g. the last file in the following list:

	var/log/neutron/00303961_0_neutron-server.log
	var/log/neutron/00303961_0_neutron-server.log.1
	var/log/neutron/00303961_0_neutron-server.log.tar.gz

We need to gracefully accept the non-standard filename and proceed.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>