### PR TITLE
Add new sosreport plugin

### DIFF
--- a/common/issue_types.py
+++ b/common/issue_types.py
@@ -42,3 +42,7 @@ class OpenstackWarning(IssueTypeBase):
 
 class OpenvSwitchWarning(IssueTypeBase):
     pass
+
+
+class SOSReportWarning(IssueTypeBase):
+    pass

--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -85,6 +85,10 @@ plugins:
       services:
         - RabbitMQServiceChecks
         - get_rabbitmq_package_checker
+  sosreport:
+    parts:
+      plugin_checks:
+        - SOSReportPluginChecks
   storage:
     parts:
       ceph_general:

--- a/hotsos.sh
+++ b/hotsos.sh
@@ -57,6 +57,7 @@ declare -A PLUGINS=(
     [juju]=false
     [kernel]=false
     [rabbitmq]=false
+    [sosreport]=false
     [system]=true  # always do system by default
     [all]=false
 )
@@ -64,6 +65,7 @@ override_all_default=false
 # output ordering
 declare -a PLUGIN_NAMES=(
     system
+    sosreport
     openstack
     openvswitch
     rabbitmq

--- a/plugins/sosreport/parts/main.py
+++ b/plugins/sosreport/parts/main.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python3
+from common.plugintools import PluginRunner
+
+if __name__ == "__main__":
+    PluginRunner()()

--- a/plugins/sosreport/parts/pyparts/plugin_checks.py
+++ b/plugins/sosreport/parts/pyparts/plugin_checks.py
@@ -1,0 +1,43 @@
+import os
+
+from common import (
+    constants,
+    issue_types,
+    issues_utils,
+    plugintools,
+)
+from common.searchtools import (
+    SearchDef,
+    FileSearcher,
+)
+
+YAML_PRIORITY = 0
+
+
+class SOSReportPluginChecks(plugintools.PluginPartBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.searcher = FileSearcher()
+
+    def check_plugin_timouts(self):
+        if not os.path.exists(os.path.join(constants.DATA_ROOT, 'sos_logs')):
+            return
+
+        path = os.path.join(constants.DATA_ROOT, 'sos_logs/ui.log')
+        self.searcher.add_search_term(SearchDef(r".* Plugin (\S+) timed out.*",
+                                                tag="timeouts"), path=path)
+        results = self.searcher.search()
+        timeouts = []
+        for r in results.find_by_tag("timeouts"):
+            plugin = r.get(1)
+            timeouts.append(plugin)
+            msg = ("sosreport plugin '{}' has timed out and may have "
+                   "incomplete data".format(plugin))
+            issues_utils.add_issue(issue_types.SOSReportWarning(msg))
+
+        if timeouts:
+            self._output["plugin-timeouts"] = timeouts
+
+    def __call__(self):
+        self.check_plugin_timouts()

--- a/tests/unit/test_sosreport.py
+++ b/tests/unit/test_sosreport.py
@@ -1,0 +1,29 @@
+import os
+
+import tempfile
+
+import utils
+
+utils.add_sys_plugin_path("sosreport")
+from plugins.sosreport.parts.pyparts import (  # noqa E402
+    plugin_checks,
+)
+
+
+class TestSOSReportPluginPartPluginChecks(utils.BaseTestCase):
+
+    def test_check_plugin_timouts_none(self):
+        inst = plugin_checks.SOSReportPluginChecks()
+        inst()
+        self.assertIsNone(inst.output)
+
+    def test_check_plugin_timouts_some(self):
+        with tempfile.TemporaryDirectory() as dtmp:
+            os.environ["DATA_ROOT"] = dtmp
+            os.makedirs(os.path.join(dtmp, "sos_logs"))
+            with open(os.path.join(dtmp, "sos_logs", 'ui.log'), 'w') as fd:
+                fd.write(" Plugin networking timed out\n")
+
+            inst = plugin_checks.SOSReportPluginChecks()
+            inst()
+            self.assertEquals(inst.output, {"plugin-timeouts": ["networking"]})


### PR DESCRIPTION
This currently has one part that checks for sosreport
plugin timeouts. When a sosreport plugin times out this
typically means that the resulting data is incomplete
hence why it is important for hotsos to report this.

Resolves: #95