### PR TITLE
[storage] check for ceph-osd bcache vulnerability

### DIFF
--- a/common/checks.py
+++ b/common/checks.py
@@ -2,6 +2,7 @@ import os
 
 import operator
 import re
+import subprocess
 import yaml
 
 from common import (
@@ -467,6 +468,33 @@ class ServiceChecksBase(object):
     def __call__(self):
         """This can/should be extended by inheriting class."""
         self._get_running_services()
+
+
+class DPKGVersionCompare(object):
+
+    def __init__(self, a):
+        self.a = a
+
+    def _exec(self, op, b):
+        try:
+            subprocess.check_call(['dpkg', '--compare-versions',
+                                   self.a, op, b])
+        except subprocess.CalledProcessError as se:
+            if se.returncode == 1:
+                return False
+
+            raise se
+
+        return True
+
+    def __eq__(self, b):
+        return self._exec('eq', b)
+
+    def __lt__(self, b):
+        return not self._exec('ge', b)
+
+    def __gt__(self, b):
+        return not self._exec('le', b)
 
 
 class PackageChecksBase(object):

--- a/common/cli_helpers.py
+++ b/common/cli_helpers.py
@@ -332,6 +332,20 @@ def get_udevadm_info_dev(dev):
 
 
 @catch_exceptions(OSError)
+def get_udevadm_info_exportdb():
+    if DATA_ROOT == '/':
+        output = subprocess.check_output(['udevadm', 'info', '--export-db'])
+        return output.decode('UTF-8').splitlines(keepends=True)
+
+    path = os.path.join(DATA_ROOT,
+                        "sos_commands/devices/udevadm_info_--export-db")
+    if os.path.exists(path):
+        return open(path, 'r').readlines()
+
+    return []
+
+
+@catch_exceptions(OSError)
 def get_ip_netns():
     if DATA_ROOT == '/':
         output = subprocess.check_output(['ip', 'netns'])

--- a/common/plugins/storage.py
+++ b/common/plugins/storage.py
@@ -6,6 +6,12 @@ from common import (
     checks,
     constants,
     plugintools,
+    utils,
+)
+from common.searchtools import (
+    FileSearcher,
+    SequenceSearchDef,
+    SearchDef
 )
 
 
@@ -19,15 +25,81 @@ CEPH_LOGS = "var/log/ceph/"
 
 
 class StorageChecksBase(plugintools.PluginPartBase):
-    pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class CephChecksBase(StorageChecksBase, checks.ServiceChecksBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bcache_info = []
+        udevadm_db = checks.cli_helpers.get_udevadm_info_exportdb()
+        if udevadm_db:
+            self.udevadm_db = utils.mktemp_dump('\n'.join(udevadm_db))
+        else:
+            self.udevadm_db = None
+
+    def __del__(self):
+        if self.udevadm_db:
+            os.unlink(self.udevadm_db)
 
     @property
     def output(self):
         if self._output:
             return {"ceph": self._output}
+
+    @property
+    def bcache_info(self):
+        if self._bcache_info:
+            return self._bcache_info
+
+        devs = []
+        s = FileSearcher()
+        sdef = SequenceSearchDef(start=SearchDef(r"^P: .+/(bcache\S+)"),
+                                 body=SearchDef(r"^S: disk/by-uuid/(\S+)"),
+                                 tag="bcacheinfo")
+        s.add_search_term(sdef, self.udevadm_db)
+        results = s.search()
+        for section in results.find_sequence_sections(sdef).values():
+            dev = {}
+            for r in section:
+                if r.tag == sdef.start_tag:
+                    dev["name"] = r.get(1)
+                else:
+                    dev["by-uuid"] = r.get(1)
+
+            devs.append(dev)
+
+        self._bcache_info = devs
+        return self._bcache_info
+
+    def is_bcache_device(self, dev):
+        """
+        Returns True if the device either is or is based on a bcache device
+        e.g. dmcrypt device using bcache dev.
+        """
+        if dev.startswith("bcache"):
+            return True
+
+        if dev.startswith("/dev/bcache"):
+            return True
+
+        ret = re.compile(r"/dev/mapper/crypt-(\S+)").search(dev)
+        if ret:
+            for dev in self.bcache_info:
+                if dev.get("by-uuid") == ret.group(1):
+                    return True
+
+    def daemon_pkg_version(self, daemon):
+        """Get version of local daemon based on package installed.
+
+        This is prone to inaccuracy since the deamom many not have been
+        restarted after package update.
+        """
+        pkginfo = checks.APTPackageChecksBase(CEPH_PKGS_CORE)
+        return pkginfo.get_version(daemon)
 
     @property
     def osd_ids(self):
@@ -46,7 +118,9 @@ class CephChecksBase(StorageChecksBase, checks.ServiceChecksBase):
 
 
 class CephConfig(checks.SectionalConfigBase):
-    pass
+    def __init__(self, *args, **kwargs):
+        path = os.path.join(constants.DATA_ROOT, '/etc/ceph/ceph.conf')
+        super().__init__(path=path, *args, **kwargs)
 
 
 class BcacheChecksBase(StorageChecksBase):
@@ -61,6 +135,16 @@ class BcacheChecksBase(StorageChecksBase):
         path = os.path.join(constants.DATA_ROOT, "sys/fs/bcache/*")
         for entry in glob.glob(path):
             if os.path.exists(os.path.join(entry, "cache_available_percent")):
-                cachesets.append(entry)
+                cachesets.append({"path": entry,
+                                  "uuid": os.path.basename(entry)})
+
+        for cset in cachesets:
+            path = os.path.join(cset['path'], "cache_available_percent")
+            with open(path) as fd:
+                value = fd.read().strip()
+                cset["cache_available_percent"] = int(value)
+
+            # dont include in final output
+            del cset["path"]
 
         return cachesets


### PR DESCRIPTION
If ceph osds are using bcache and bluefs_buffered_io is True
when using older kernels the host will be susceptible to major
performance issues as described in LP bug 1936136. If we think
these conditions are met we will raise an issue to warn the
user.

Resolves: #105