### PR TITLE
[kernel] alert error if Call Trace found

### DIFF
--- a/core/issues/issue_types.py
+++ b/core/issues/issue_types.py
@@ -4,6 +4,10 @@ class IssueTypeBase(object):
         self.msg = msg
 
 
+class KernelError(IssueTypeBase):
+    pass
+
+
 class MemoryWarning(IssueTypeBase):
     pass
 

--- a/defs/events.yaml
+++ b/defs/events.yaml
@@ -118,20 +118,21 @@ openvswitch:
         expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN)\|.+'
         hint: '(ERR|WARN)'
 kernel:
-  memory-checks:
-    kernlog:
+  kernlog:
+    path: 'var/log/kern.log'
+    common:
+      stacktrace:
+        expr: '.*Call Trace:'
+        hint: 'Call'
+    memory:
       oom-killer-invoked:
-        path: 'var/log/kern.log'
         expr: '(.+ \d+) (\d+:\d+:\d+) .+ (\S+) invoked oom-killer\:'
         hint: 'oom'
-  network-checks:
-    kernlog:
+    network:
       over-mtu-dropped-packets:
-        path: 'var/log/kern.log'
         expr: '.+\] (\S+): dropped over-mtu packet'
         hint: 'dropped'
       nf-conntrack-full:
-        path: 'var/log/kern.log'
         expr: '.+ nf_conntrack: table full, dropping packet'
         hint: 'conntrack'
 rabbitmq:

--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -70,9 +70,8 @@ plugins:
         - KernelGeneralChecks
       memory:
         - KernelMemoryChecks
-        - KernelMemoryEventChecks
-      network:
-        - KernelNetworkChecks
+      log_event_checks:
+        - KernelLogEventChecks
   kubernetes:
     parts:
       general:

--- a/plugins/kernel/pyparts/memory.py
+++ b/plugins/kernel/pyparts/memory.py
@@ -1,39 +1,17 @@
 import os
 
-from core.checks import CallbackHelper
 from core.issues import (
     issue_types,
     issue_utils,
 )
 from core.plugins.kernel import (
     KernelChecksBase,
-    KernelEventChecksBase,
     VMSTAT,
     BUDDY_INFO,
     SLABINFO,
 )
 
 YAML_PRIORITY = 1
-EVENTCALLBACKS = CallbackHelper()
-
-
-class KernelMemoryEventChecks(KernelEventChecksBase):
-
-    def __init__(self):
-        super().__init__(yaml_defs_group='memory-checks',
-                         callback_helper=EVENTCALLBACKS)
-
-    @EVENTCALLBACKS.callback
-    def oom_killer_invoked(self, event):
-        results = event['results']
-        process_name = results[0].get(3)
-        time_oomd = "{} {}".format(results[0].get(1),
-                                   results[0].get(2))
-        msg = ("oom-killer invoked for process '{}' at {}"
-               .format(process_name, time_oomd))
-        issue = issue_types.MemoryWarning(msg)
-        issue_utils.add_issue(issue)
-        return time_oomd
 
 
 class KernelMemoryChecks(KernelChecksBase):

--- a/tests/unit/fake_data_root/var/log/kern.log
+++ b/tests/unit/fake_data_root/var/log/kern.log
@@ -1795,3 +1795,15 @@ May  6 17:24:13 compute4 kernel: [13526370.730634] tape901c8af-fb: dropped over-
 May  6 17:24:13 compute4 kernel: [13526370.730659] tape901c8af-fb: dropped over-mtu packet: 1460 > 1450
 May  6 17:24:13 compute4 kernel: [13526370.730681] tape901c8af-fb: dropped over-mtu packet: 1460 > 1450
 Jun  8 10:48:13 compute4 kernel: [1694413.621694] nf_conntrack: nf_conntrack: table full, dropping packet
+
+May  6 10:49:21 tututu kernel: [ 4965.415911] CPU: 1 PID: 4465 Comm: insmod Tainted: P           OE   4.13.0-rc5 #1
+May  6 10:49:21 tututu kernel: [ 4965.415912] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1.fc26 04/01/2014
+May  6 10:49:21 tututu kernel: [ 4965.415913] Call Trace:
+May  6 10:49:21 tututu kernel: [ 4965.415920]  dump_stack+0x63/0x8b
+May  6 10:49:21 tututu kernel: [ 4965.415923]  do_init_module+0x8d/0x1e9
+May  6 10:49:21 tututu kernel: [ 4965.415926]  load_module+0x21bd/0x2b10
+May  6 10:49:21 tututu kernel: [ 4965.415929]  SYSC_finit_module+0xfc/0x120
+May  6 10:49:21 tututu kernel: [ 4965.415931]  ? SYSC_finit_module+0xfc/0x120
+May  6 10:49:21 tututu kernel: [ 4965.415934]  SyS_finit_module+0xe/0x10
+May  6 10:49:21 tututu kernel: [ 4965.415937]  entry_SYSCALL_64_fastpath+0x1a/0xa5
+May  6 10:49:21 tututu kernel: [ 4965.415939] RIP: 0033:0x7fab36d717a9


### PR DESCRIPTION
If we detect a stacktrace in kern.log* we will
alert with a KernelError.

Resolves: #110