### PR TITLE
Add Octavia HM port to network configs

### DIFF
--- a/core/host_helpers.py
+++ b/core/host_helpers.py
@@ -13,7 +13,7 @@ from core.searchtools import (
 IP_IFACE_NAME = r"^\d+:\s+(\S+):\s+.+"
 IP_IFACE_NAME_TEMPLATE = r"^\d+:\s+({}):\s+.+"
 IP_IFACE_V4_ADDR = r".+(inet) ([\d\.]+)/(\d+) (?:brd \S+ )?scope global (\S+)"
-IP_IFACE_V6_ADDR = r".+(inet6) ([\d\:]+)/(\d+) scope global.*"
+IP_IFACE_V6_ADDR = r".+(inet6) (\S+)/(\d+) scope global (\S+)"
 IP_IFACE_HW_ADDR = r".+(link/ether) (\S+) brd .+"
 IP_IFACE_HW_ADDR_TEMPLATE = r".+(link/ether) {} brd .+"
 IP_IFACE_VXLAN_INFO = r"\s+(vxlan) id (\d+) local (\S+) dev (\S+) .+"
@@ -169,6 +169,11 @@ class HostNetworkingHelper(object):
             for _addr in iface.addresses:
                 if _addr.startswith(addr):
                     return iface
+
+    def get_interface_with_name(self, name):
+        for iface in self.host_interfaces_all:
+            if iface.name == name:
+                return iface
 
     def host_interface_exists(self, name, check_namespaces=True):
         names = [_iface.name for _iface in self.host_interfaces]

--- a/core/issues/issue_types.py
+++ b/core/issues/issue_types.py
@@ -62,3 +62,7 @@ class SOSReportWarning(IssueTypeBase):
 
 class SysCtlWarning(IssueTypeBase):
     pass
+
+
+class OpenstackError(IssueTypeBase):
+    pass

--- a/core/plugins/openstack/__init__.py
+++ b/core/plugins/openstack/__init__.py
@@ -288,6 +288,19 @@ class OpenstackBase(object):
         return interfaces
 
     @property
+    def octavia_bind_interfaces(self):
+        """
+        Fetch interface o-hm0 used by Openstack Octavia. Returned dict is
+        keyed by config key used to identify interface.
+        """
+        interfaces = {}
+        port = self.nethelp.get_interface_with_name('o-hm0')
+        if port:
+            interfaces.update({'o-hm0': port})
+
+        return interfaces
+
+    @property
     def bind_interfaces(self):
         """
         Fetch interfaces used by Openstack services and return dict.

--- a/plugins/openstack/pyparts/network.py
+++ b/plugins/openstack/pyparts/network.py
@@ -1,5 +1,9 @@
 import re
 
+from core.issues import (
+    issue_types,
+    issue_utils,
+)
 from core.cli_helpers import CLIHelper
 from core.plugins.openstack import OpenstackChecksBase
 
@@ -68,6 +72,19 @@ class OpenstackNetworkChecks(OpenstackChecksBase):
 
             config_info['nova'][key] = "{} ({})".format(port.addresses[0],
                                                         port.name)
+
+        for key, port in self.octavia_bind_interfaces.items():
+            if 'octavia' not in config_info:
+                config_info['octavia'] = {}
+
+            if port.addresses:
+                config_info['octavia'][key] = "{} ({})".format(
+                        port.addresses[0], port.name)
+            else:
+                msg = ("No IP address found on Octavia Health manager port "
+                       "({}). Octavia will not be able to communicate with "
+                       "Amphora VMs - please investigate.".format(port.name))
+                issue_utils.add_issue(issue_types.OpenstackError(msg))
 
         if config_info:
             self._output["config"] = config_info

--- a/tests/unit/fake_data_root/sos_commands/networking/ip_-d_address
+++ b/tests/unit/fake_data_root/sos_commands/networking/ip_-d_address
@@ -114,3 +114,10 @@
        valid_lft forever preferred_lft forever
     inet6 fe80::5054:45ff:fe57:65e7/64 scope link 
        valid_lft forever preferred_lft forever
+14: o-hm0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8950 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/ether fa:16:3e:4f:ed:8a brd ff:ff:ff:ff:ff:ff promiscuity 1 minmtu 68 maxmtu 65535
+    openvswitch numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
+    inet6 fc00:2203:1448:17b7:f816:3eff:fe4f:ed8a/64 scope global dynamic mngtmpaddr noprefixroute
+       valid_lft 86352sec preferred_lft 14352sec
+    inet6 fe80::f816:3eff:fe4f:ed8a/64 scope link
+       valid_lft forever preferred_lft forever

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -11,7 +11,7 @@ class TestHostHelpers(utils.BaseTestCase):
                     'br-tun', 'br-ex', 'br-int', 'br-data', 'lxdbr0',
                     '1lxd0-0@if22', '1lxd1-0@if24', '1lxd2-0@if26',
                     '1lxd3-0@if28', 'tap03c4d61b-60', 'tap0906171f-17',
-                    'bond1', 'br-bond1', 'bond1.4003@bond1']
+                    'bond1', 'br-bond1', 'bond1.4003@bond1', 'o-hm0']
         helper = HostNetworkingHelper()
         ifaces = helper.host_interfaces
         names = [iface.name for iface in ifaces]
@@ -23,11 +23,11 @@ class TestHostHelpers(utils.BaseTestCase):
                     'br-tun', 'br-ex', 'br-int', 'br-data', 'lxdbr0',
                     '1lxd0-0@if22', '1lxd1-0@if24', '1lxd2-0@if26',
                     '1lxd3-0@if28', 'tap03c4d61b-60', 'tap0906171f-17',
-                    'bond1', 'br-bond1', 'bond1.4003@bond1', 'lo',
-                    'fpr-1e086be2-9@if2', 'fg-7450b342-b1', 'lo',
-                    'fpr-1e086be2-9@if2', 'fg-7450b342-b1', 'lo',
-                    'fpr-1e086be2-9@if2', 'fg-7450b342-b1', 'lo',
-                    'fpr-1e086be2-9@if2', 'fg-7450b342-b1']
+                    'bond1', 'br-bond1', 'bond1.4003@bond1', 'o-hm0',
+                    'lo', 'fpr-1e086be2-9@if2', 'fg-7450b342-b1',
+                    'lo', 'fpr-1e086be2-9@if2', 'fg-7450b342-b1',
+                    'lo', 'fpr-1e086be2-9@if2', 'fg-7450b342-b1',
+                    'lo', 'fpr-1e086be2-9@if2', 'fg-7450b342-b1']
         helper = HostNetworkingHelper()
         ifaces = helper.host_interfaces_all
         names = [iface.name for iface in ifaces]

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -320,17 +320,34 @@ class TestOpenstackPluginPartNetwork(TestOpenstackBase):
         self.assertEqual(inst.output, None)
 
     def test_get_network_checker(self):
-        expected = {'config':
-                    {'nova':
-                        {'my_ip': '10.0.0.49 (br-ens3)'},
-                     'neutron':
-                        {'local_ip': '10.0.0.49 (br-ens3)'}},
-                    'namespaces':
-                        {'fip': 1, 'qdhcp': 1, 'qrouter': 1, 'snat': 1},
-                    'port-health':
-                        {'phy-ports':
-                         {'br-ens3': {
-                             'rx': {'dropped': '131579 (36%)'}}}}}
+        expected = {
+            'config': {
+                'nova': {
+                    'my_ip': '10.0.0.49 (br-ens3)'
+                },
+                'neutron': {
+                    'local_ip': '10.0.0.49 (br-ens3)'
+                },
+                'octavia': {
+                    'o-hm0': 'fc00:2203:1448:17b7:f816:3eff:fe4f:ed8a (o-hm0)'
+                }
+            },
+            'namespaces': {
+                'fip': 1,
+                'qdhcp': 1,
+                'qrouter': 1,
+                'snat': 1
+            },
+            'port-health': {
+                'phy-ports': {
+                    'br-ens3': {
+                        'rx': {
+                            'dropped': '131579 (36%)'
+                        }
+                    }
+                }
+            }
+        }
         inst = network.OpenstackNetworkChecks()
         inst()
         self.assertEqual(inst.output["network"], expected)


### PR DESCRIPTION
This patch adds Octavia Health manager IP address to the
network configs section if o-hm0 port exists. If there is
no IP address to o-hm0, will be notified in potential issues.

Resolves: #122