### PR TITLE
[storage] Improve bluefs_buffered_io versioning accuracy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ definitions categories:
            operation on the information retreived.  See yaml file for full
            description.
 
-* config_checks - Defines criteria for indentifying invalid application
+* config_checks - Defines criteria for identifying invalid application
                   configuration. See yaml file for full description. 
  
 * package\_bug\_checks - Defines criteria for identifying whether installed

--- a/core/checks.py
+++ b/core/checks.py
@@ -730,6 +730,12 @@ class DPKGVersionCompare(object):
     def __gt__(self, b):
         return not self._exec('le', b)
 
+    def __le__(self, b):
+        return self._exec('le', b)
+
+    def __ge__(self, b):
+        return self._exec('ge', b)
+
 
 def dict_to_formatted_str_list(f):
     """

--- a/plugins/storage/pyparts/ceph_daemon_checks.py
+++ b/plugins/storage/pyparts/ceph_daemon_checks.py
@@ -192,18 +192,19 @@ class CephOSDChecks(ceph.CephChecksBase):
                 return
 
         # Get version of osd based on package installed. This is prone to
-        # inaccuracy since the deamom many not have been restarted after
+        # inaccuracy since the daemon many not have been restarted after
         # package update.
         current = self.apt_check.get_version('ceph-osd')
-        if current < DPKGVersionCompare("13.2.0"):
+        if current <= DPKGVersionCompare("13.0.1"):
             return
-
-        if current < DPKGVersionCompare("15.2.0"):
-            if current > DPKGVersionCompare("14.2.0"):
-                if current > DPKGVersionCompare("14.2.10"):
-                    if current < DPKGVersionCompare("14.2.22"):
-                        return
-        elif current < DPKGVersionCompare("15.2.13"):
+        if current >= DPKGVersionCompare("14.2.10") and \
+           current <= DPKGVersionCompare("14.2.21"):
+            return
+        if current >= DPKGVersionCompare("15.2.2") and \
+           current <= DPKGVersionCompare("15.2.12"):
+            return
+        if current == DPKGVersionCompare("16.1.0") or \
+           current == DPKGVersionCompare("17.0.0"):
             return
 
         if KernelChecksBase().version >= "5.4":


### PR DESCRIPTION
Some further filtering done  - this is accurate as of all the available Ceph releases today.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>